### PR TITLE
`hero-card` seems to be undefined

### DIFF
--- a/frontend/src/components/Hero.jsx
+++ b/frontend/src/components/Hero.jsx
@@ -4,7 +4,7 @@ const Hero = () => {
   return (
     <div className=' py-5'>
       <Container className='d-flex justify-content-center'>
-        <Card className='p-5 d-flex flex-column align-items-center hero-card bg-light w-75'>
+        <Card className='p-5 d-flex flex-column align-items-center bg-light w-75'>
           <h1 className='text-center mb-4'>MERN Authentication</h1>
           <p className='text-center mb-4'>
             This is a boilerplate for MERN authentication that stores a JWT in


### PR DESCRIPTION
I watched the video and could not find any definition for `hero-card`. I ran the example on my system, and indeed it seems to be from a template that was used previoulsy.

As I am a beginner, this took me some time to research as I thought it had some effect on the height, for example, so maybe the class being removed will prevent others from having to investigate.